### PR TITLE
LaunchJsonFixVSCode Fix for launching mocha

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node",
       "request": "launch",
       "runtimeArgs": [
-        "${workspaceRoot}/node_modules/.bin/mocha",
+        "${workspaceRoot}/node_modules/mocha/bin/mocha",
         "--inspect-brk",
         "${relativeFile}",
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "cda-schematron-validator",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "name": "cda-schematron-validator",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "~0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cda-schematron-validator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Fork of Eric Wadkins' javascript implementation of schematron testing for C-CDA XML documents. This includes bug fixes and some house keeping.",
   "main": "validator.js",
   "scripts": {
@@ -35,8 +35,8 @@
     "mocha": "~9.2.2"
   },
   "dependencies": {
-    "lodash.get": "~4.4.2",
     "@xmldom/xmldom": "~0.7.2",
+    "lodash.get": "~4.4.2",
     "xpath": "~0.0.32"
   },
   "directories": {


### PR DESCRIPTION
Launching mocha on windows causes issue listed here
https://github.com/npm/cmd-shim/issues/17
as it expects a cmd file not a js file. Specifying full path to avoid
the issue.