### PR TITLE
RegressionFix_1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # [cda-schematron-validator](https://github.com/priyaranjan-tokachichu/cda-schematron-validator)
 ## Release History
 Starting release history with 1.0.7
+### 1.0.9
+- Fixed the bug introduced in 1.0.8 trying to adjust to different data types of the return value
+- Changed variable names to improve understanding of the process
 ### 1.0.8
 - Bug fix identifying the ignored errors
 ### 1.0.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cda-schematron-validator",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Fork of Eric Wadkins' javascript implementation of schematron testing for C-CDA XML documents. This includes bug fixes and some house keeping.",
   "main": "validator.js",
   "scripts": {


### PR DESCRIPTION
While trying to understand the ignored errors, and different data types
returning for the same method, a bug was introduced. This bug should
not have been in place if the tests were run. A better process will be
introduced in the future to avoid regressions.