### PR TITLE
v1.1.4 Deviations from the parent repository

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,12 +18,13 @@ module.exports = {
         'object-curly-spacing': 0,
         'func-call-spacing': 0,
         'max-len': [2, {
-            code: 200,
-            tabWidth: 4,
-            ignoreUrls: true,
-            ignorePattern: 'goog\.(module|require)',
-            ignoreStrings: true,
-            ignoreComments: true
-        }]
+            'code': 200,
+            'tabWidth': 4,
+            'ignoreUrls': true,
+            'ignorePattern': 'goog\.(module|require)',
+            'ignoreStrings': true,
+            'ignoreComments': true
+        }],
+        'brace-style': ['error', 'stroustrup']
     }
 };

--- a/README.md
+++ b/README.md
@@ -1,34 +1,68 @@
 # [cda-schematron-validator](https://github.com/priyaranjan-tokachichu/cda-schematron-validator)
+
 ## Release History
+
 Starting release history with 1.0.7
-### 1.1.1
+
+### 1.1.4 (Stable Release)
+
+- Major deviations from the source repository
+
+  - By default the warning will be turned off in contrast to the parent repository
+
+  - To get warnings, users have to explicitly specify the option `includeWarnings` with value boolean `true`
+
+  - We also deviate from the previous behavior where all the checks for warnings were done at the assertion
+    level just before testing the xpath. We now would not even parse the phase with @id="warnings" which should
+    improve the performance.
+
+- Minor cosmetic changes to the code
+
+### 1.1.1 to 1.1.3
+
 - Only keeping the necessary data in the test files taken from HL7 C-CDA schematron repository to avoid bloating the module
+
+- Added pre-commit hooks with husky
+
+- Added code standardization with prettier, ESLint, and lint-staged
+
 ### 1.1.0
+
 - Fix the issue with the rule check which was working in the original repository, but not in the fork
-- Added HL7 C-CDA schematron file and resource file from https://github.com/HL7/CDA-ccda-2.1/releases/tag/2019JUN
+- Added HL7 C-CDA schematron file and resource file from <https://github.com/HL7/CDA-ccda-2.1/releases/tag/2019JUN>
 - Added a test case vitalSigns.test.js that tests the resource file and sub assertions
-- Used resources https://github.com/jddamore/ccda-samples and https://github.com/HL7/C-CDA-Examples/tree/master/Vital%20Signs to create the test file vitalSigns.xml
+- Used resources <https://github.com/jddamore/ccda-samples> and <https://github.com/HL7/C-CDA-Examples/tree/master/Vital%20Signs> to create the test file vitalSigns.xml
+
 ### 1.0.10
+
 - Fix null context issue associated with assertions within assertions
 - Skip abstract rules associated with assertions within assertions
+
 ### 1.0.9
+
 - Fixed the bug introduced in 1.0.8 trying to adjust to different data types of the return value
 - Changed variable names to improve understanding of the process
+
 ### 1.0.8
+
 - Bug fix identifying the ignored errors
+
 ### 1.0.7
+
 - Added async validate function `validateAsync`
 - Added `testsAsync` to test `validateAsync`
 - Plan to use common functions between sync and async methods in the future release
 
 ### 1.0.0 to 1.0.6
-A fork to the original cda-schematron. All credit to Eric Wadkins. Visit the github https://github.com/ewadkins/cda-schematron for the original repo.
+
+A fork to the original cda-schematron. All credit to Eric Wadkins. Visit the github <https://github.com/ewadkins/cda-schematron> for the original repo.
 
 This is just a cosmetic change with updated node modules, a couple of minor bugs observed, and esversion 6 changes.
 
-The changes are fully backward compatible. So, leaving the original documentation as is below. 
+The changes are fully backward compatible. So, leaving the original documentation as is below.
 
 ### New option parameter parsedSchematronMap
+
 In addition to everything that was possible,
 you can now supply a new option parameter `parsedSchematronMap`. You can create a schematron map as follows.
 
@@ -44,24 +78,25 @@ const options = {
     };
 const results =  validate('xml string or file path', 'schematron sting, file path or null', options);
 ```
+
 If a schematron map is provided, the schematron string or path will not be read.
 
 To install this npm module, it will be
 
+```javascript
+npm i cda-schematron-validator
 ```
-npm install cda-schematron-validator
-```
+
 Mocha VS Code configuratin added to directly execute the test file in `test/tests.js` using VS Code.
 
-
-# Original Documentation of the cda-schematron
-## [cda-schematron](https://github.com/ewadkins/cda-schematron)
+## Documentation of the parent repo [cda-schematron](https://github.com/ewadkins/cda-schematron)
 
 A javascript implementation of schematron testing for XML documents. This specifically resolves a need for a package that allows a quick, reliable install for validating HL7 clinical documents, such as C-CDA.
 
 Check out [cda-schematron-server](https://github.com/ewadkins/cda-schematron-server), a server wrapper of **cda-schematron**, for easy schematron validation.
 
 ### Validating xml
+
 ```javascript
 var validator = require('cda-schematron');
 
@@ -74,21 +109,27 @@ var schematron = fs.readFileSync(schematronPath).toString();
 
 var results = validator.validate(xml, schematron);
 ```
+
 File paths can also be passed to the validator directly. The following lines all return the same results:
+
 ```javascript
 var results = validator.validate(xml, schematronPath);
 ```
+
 ```javascript
 var results = validator.validate(xmlPath, schematron);
 ```
+
 ```javascript
 var results = validator.validate(xmlPath, schematronPath);
 ```
 
 ### Results
+
 ```results``` is an object containing arrays  ```errors```, ```warnings```, and ```ignoreds```.
 
 **Errors** and **warnings** are reported as determined by the schematron and test descriptions. They are of the following form:
+
 ```javascript
 {
     type: type,                     // "error" or "warning"
@@ -106,6 +147,7 @@ var results = validator.validate(xmlPath, schematronPath);
 ```
 
 **Ignored** tests are those that resulted in an exception while running (eg. the test is invalid xpath and could not be parsed properly) and require manual inspection. They are of the following form:
+
 ```javascript
 {
     errorMessage: errorMessage,     // reason for the exception/ignoring the test
@@ -121,13 +163,14 @@ var results = validator.validate(xmlPath, schematronPath);
 ```
 
 ### Options
+
 The ```validate``` function takes in an ```options``` object as an optional third argument. The three fields that can be included in ```options``` are as follows:
 
-* **```includeWarnings```**: ```true``` or ```false```, this determines whether or not warnings should be tested and returned. Defaults to ```true```.
+- **```includeWarnings```**: ```true``` or ```false```, this determines whether or not warnings should be tested and returned. Defaults to ```true```.
 
-* **```resourceDir```**: the path to a directory containing resource files (eg. voc.xml) which may be necessary for some schematron tests. Defaults to ```'./'```, the current directory.
+- **```resourceDir```**: the path to a directory containing resource files (eg. voc.xml) which may be necessary for some schematron tests. Defaults to ```'./'```, the current directory.
 
-* **```xmlSnippetMaxLength```**: an integer, which is the maximum length of the ```xml``` field in validation results. Defaults to ```200```. Set to ```0``` for unlimited length.
+- **```xmlSnippetMaxLength```**: an integer, which is the maximum length of the ```xml``` field in validation results. Defaults to ```200```. Set to ```0``` for unlimited length.
 
 Here is an example with warnings disabled:
 
@@ -136,12 +179,15 @@ var results = validator.validate(xml, schematron, { includeWarnings: false });
 ```
 
 ### Cache
+
 The validator uses a cache to store parsed schematrons, an intermediate data structure used to store revelant schematron information. This reduces the runtime of the validator when validating against the same schematron multiple times. You can clear the cache at any time with:
+
 ```javascript
 validator.clearCache();
 ```
 
 ---
+
 ## License (MIT)
 
 Copyright &copy; 2017 [Eric Wadkins](http://www.ericwadkins.com/)

--- a/includeExternalDocument.js
+++ b/includeExternalDocument.js
@@ -23,7 +23,8 @@ function modifyTest(test, resourceDir) {
             }
             if (test[i] === ']') {
                 bracketDepth++;
-            } else if (test[i] === '[') {
+            }
+            else if (test[i] === '[') {
                 bracketDepth--;
             }
         }
@@ -37,7 +38,8 @@ function modifyTest(test, resourceDir) {
             }
             if (test[i] === '[') {
                 bracketDepth++;
-            } else if (test[i] === ']') {
+            }
+            else if (test[i] === ']') {
                 bracketDepth--;
             }
         }
@@ -51,12 +53,14 @@ function modifyTest(test, resourceDir) {
             let externalXml = null;
             try {
                 externalXml = fs.readFileSync(path.join(resourceDir, filepath), 'utf-8').toString();
-            } catch (err) {
+            }
+            catch (err) {
                 throw new Error('No such file \'' + filepath + '\'');
             }
             externalDoc = new Dom().parseFromString(externalXml);
             loadedExternalDocuments[filepath] = externalDoc;
-        } else {
+        }
+        else {
             externalDoc = loadedExternalDocuments[filepath];
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cda-schematron-validator",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Fork of Eric Wadkins' javascript implementation of schematron testing for C-CDA XML documents. This includes bug fixes and some house keeping.",
   "main": "validator.js",
   "scripts": {

--- a/parseSchematron.js
+++ b/parseSchematron.js
@@ -3,20 +3,20 @@
 module.exports = parseSchematron;
 
 const xpath = require('xpath');
+const _get = require('lodash.get');
 
-function parseSchematron(doc) {
+function parseSchematron(doc, options) {
     // Extract data from schematron
-    const schematronData = extract(doc);
+    const schematronData = extract(doc, options);
 
     return schematronData;
 }
 
-function extract(doc) {
+function extract(doc, options) {
     const namespaceMap = Object.create({});
     const patternLevelMap = Object.create({});
     const patternRuleMap = Object.create({});
     const ruleAssertionMap = Object.create({});
-
     // // Namespace mapping
     const namespaces = xpath.select('//*[local-name()="ns"]', doc);
     for (let i = 0; i < namespaces.length; i++) {
@@ -41,7 +41,7 @@ function extract(doc) {
     const warningPhase = xpath.select('//*[local-name()="phase" and @id="warnings"]', doc);
 
     // Store warning patterns
-    if (warningPhase.length) {
+    if (_get(options, 'includeWarnings') && warningPhase.length) {
         for (let i = 0; i < warningPhase[0].childNodes.length; i++) {
             if (warningPhase[0].childNodes[i].localName === 'active') {
                 patternLevelMap[warningPhase[0].childNodes[i].getAttribute('pattern')] = 'warning';

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -14,7 +14,7 @@ const schematron = fs.readFileSync(schematronPath, 'utf-8').toString();
 describe('Validator should', function() {
     let results;
     it('return results', async function() {
-        results = await validator.validateAsync(xml, schematron);
+        results = await validator.validateAsync(xml, schematron, { includeWarnings: true });
         expect(results).to.be.an('object');
     });
     it('return errorCount', function() {
@@ -55,7 +55,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results without warnings', async function() {
-        results = await validator.validateAsync(xml, schematron, { includeWarnings: false });
+        results = await validator.validateAsync(xml, schematron);
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -72,7 +72,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given xml filepath', async function() {
-        results = await validator.validateAsync(xmlPath, schematron);
+        results = await validator.validateAsync(xmlPath, schematron, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -89,7 +89,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given schematron filepath', async function() {
-        results = await validator.validateAsync(xml, schematronPath);
+        results = await validator.validateAsync(xml, schematronPath, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -106,7 +106,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given xml filepath and schematron filepath', async function() {
-        results = await validator.validateAsync(xmlPath, schematronPath);
+        results = await validator.validateAsync(xmlPath, schematronPath, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');

--- a/test/tests.js
+++ b/test/tests.js
@@ -13,7 +13,7 @@ const schematron = fs.readFileSync(schematronPath, 'utf-8').toString();
 describe('Validator should', function() {
     let results;
     it('return results', function(done) {
-        results = validator.validate(xml, schematron);
+        results = validator.validate(xml, schematron, { includeWarnings: true });
         expect(results).to.be.an('object');
         done();
     });
@@ -67,7 +67,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results without warnings', function(done) {
-        results = validator.validate(xml, schematron, { includeWarnings: false });
+        results = validator.validate(xml, schematron);
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -85,7 +85,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given xml filepath', function(done) {
-        results = validator.validate(xmlPath, schematron);
+        results = validator.validate(xmlPath, schematron, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -103,7 +103,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given schematron filepath', function(done) {
-        results = validator.validate(xml, schematronPath);
+        results = validator.validate(xml, schematronPath, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');
@@ -121,7 +121,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results given xml filepath and schematron filepath', function(done) {
-        results = validator.validate(xmlPath, schematronPath);
+        results = validator.validate(xmlPath, schematronPath, { includeWarnings: true });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');

--- a/test/vitalSigns.test.js
+++ b/test/vitalSigns.test.js
@@ -12,7 +12,8 @@ const schematronPath = path.resolve(__dirname, './CDAR2_IG_CCDA_CLINNOTES_R1_DST
 const xml = fs.readFileSync(xmlPath, 'utf-8').toString();
 const schematron = fs.readFileSync(schematronPath, 'utf-8').toString();
 const options = {
-    resourceDir: path.resolve(__dirname, './')
+    resourceDir: path.resolve(__dirname, './'),
+    includeWarnings: true
 };
 
 describe('Validator should', function() {
@@ -59,7 +60,7 @@ describe('Validator should', function() {
     });
 
     it('return similar results without warnings', async function() {
-        results = await validator.validateAsync(xml, schematron, { includeWarnings: false, resourceDir: options.resourceDir });
+        results = await validator.validateAsync(xml, schematron, { resourceDir: options.resourceDir });
         expect(results).to.be.an('object');
         expect(results.errorCount).to.be.a('number');
         expect(results.warningCount).to.be.a('number');

--- a/testAssertion.js
+++ b/testAssertion.js
@@ -19,7 +19,8 @@ function testAssertion(test, selected, select, xmlDoc, resourceDir, xmlSnippetMa
                 xmlSnippet = xmlSnippet.slice(0, maxLength) + '...';
             }
             results.push({ result: result, line: lineNumber, path: getXPath(selected[i]), xml: xmlSnippet });
-        } catch (err) {
+        }
+        catch (err) {
             return { ignored: true, errorMessage: err.message };
         }
     }
@@ -51,13 +52,15 @@ function getXPath(node, path) {
         if (count === 1) {
             count = null;
         }
-    } else if (node.nextSibling) {
+    }
+    else if (node.nextSibling) {
         let sibling = node.nextSibling;
         do {
             if (sibling.nodeType === 1 && sibling.nodeName === node.nodeName) {
                 count = 1;
                 sibling = null;
-            } else {
+            }
+            else {
                 count = null;
                 sibling = sibling.previousSibling;
             }

--- a/validator.js
+++ b/validator.js
@@ -36,7 +36,8 @@ function validate(xml, schematron, options = {}) {
     if (xml.trim().indexOf('<') === -1) {
         try {
             xml = fs.readFileSync(xml, 'utf-8').toString();
-        } catch (err) {
+        }
+        catch (err) {
             // If no valid xml found, inform user, and return immediately
             console.log('No valid xml could be found');
             return;
@@ -49,13 +50,15 @@ function validate(xml, schematron, options = {}) {
     // Allowing users to send a parsed schematron map if testing multiple xml files with the same schematron
     if (options.parsedSchematronMap) {
         schematronMap = options.parsedSchematronMap;
-    } else {
+    }
+    else {
         // If not valid schematron (xml), it might be a filepath
         // Adding explicit check to make it clear
         if (schematron.trim().indexOf('<') === -1) {
             try {
                 schematron = fs.readFileSync(schematron, 'utf-8').toString();
-            } catch (err) {
+            }
+            catch (err) {
                 // If no valid schematron found, inform user, and return immediately
                 console.log('No valid schematron could be found');
                 return;
@@ -72,13 +75,12 @@ function validate(xml, schematron, options = {}) {
             const schematronDoc = new Dom().parseFromString(schematron);
 
             // Parse schematron
-            schematronMap = parseSchematron(schematronDoc);
+            schematronMap = parseSchematron(schematronDoc, options);
 
             // Cache parsed schematron
             parsedMap[hash] = schematronMap;
         }
     }
-
     // Extract data from parsed schematron object
     namespaceMap = schematronMap.namespaceMap;
     patternRuleMap = schematronMap.patternRuleMap;
@@ -128,12 +130,14 @@ function validate(xml, schematron, options = {}) {
                             };
                             if (type === 'error') {
                                 errors.push(obj);
-                            } else {
+                            }
+                            else {
                                 warnings.push(obj);
                             }
                         }
                     }
-                } else if (results.ignored) {
+                }
+                else if (results.ignored) {
                     const obj = {
                         errorMessage: errorMessage,
                         type: type,
@@ -164,7 +168,6 @@ function validate(xml, schematron, options = {}) {
 // Take the checkRule function out of validate function, and pass on the variable needed as parameters and options
 function checkRule(xmlDoc, originalContext, assertionsAndExtensions, options) {
     // Context cache
-    const includeWarnings = options.includeWarnings === undefined ? true : options.includeWarnings;
     const resourceDir = options.resourceDir || './';
     const xmlSnippetMaxLength = options.xmlSnippetMaxLength === undefined ? 200 : options.xmlSnippetMaxLength;
     const failedAssertions = [];
@@ -178,7 +181,8 @@ function checkRule(xmlDoc, originalContext, assertionsAndExtensions, options) {
                 contextModified = '//' + context;
             }
             selected = xpathSelect(contextModified, xmlDoc);
-        } else {
+        }
+        else {
             selected = [xmlDoc];
         }
         contextMap[context] = selected;
@@ -193,7 +197,8 @@ function checkRule(xmlDoc, originalContext, assertionsAndExtensions, options) {
             let simplifiedTest = null;
             try {
                 test = includeExternalDocument(test, resourceDir);
-            } catch (err) {
+            }
+            catch (err) {
                 failedAssertions.push({
                     type: level,
                     assertionId: id,
@@ -207,7 +212,7 @@ function checkRule(xmlDoc, originalContext, assertionsAndExtensions, options) {
             if (originalTest !== test) {
                 simplifiedTest = test;
             }
-            if (level === 'error' || includeWarnings) {
+            if (level === 'error' || _get(options, 'includeWarnings')) {
                 failedAssertions.push({
                     type: level,
                     assertionId: id,
@@ -217,7 +222,8 @@ function checkRule(xmlDoc, originalContext, assertionsAndExtensions, options) {
                     results: testAssertion(test, selected, xpathSelect, xmlDoc, resourceDir, xmlSnippetMaxLength)
                 });
             }
-        } else {
+        }
+        else {
             const extensionRule = assertionAndExtensionObject.rule;
             if (!extensionRule) {
                 continue;
@@ -240,7 +246,8 @@ async function validateAsync(xml, schematron, options = {}) {
     if (xml.trim().indexOf('<') === -1) {
         try {
             xml = fs.readFileSync(xml, 'utf-8').toString();
-        } catch (err) {
+        }
+        catch (err) {
             // If no valid xml found, inform user, and return immediately
             console.log('No valid xml could be found');
             return;
@@ -253,13 +260,15 @@ async function validateAsync(xml, schematron, options = {}) {
     // Allowing users to send a parsed schematron map if testing multiple xml files with the same schematron
     if (options.parsedSchematronMap) {
         schematronMap = options.parsedSchematronMap;
-    } else {
+    }
+    else {
         // If not valid schematron (xml), it might be a filepath
         // Adding explicit check to make it clear
         if (schematron.trim().indexOf('<') === -1) {
             try {
                 schematron = fs.readFileSync(schematron, 'utf-8').toString();
-            } catch (err) {
+            }
+            catch (err) {
                 // If no valid schematron found, inform user, and return immediately
                 console.log('No valid schematron could be found');
                 return;
@@ -276,7 +285,7 @@ async function validateAsync(xml, schematron, options = {}) {
             const schematronDoc = new Dom().parseFromString(schematron);
 
             // Parse schematron
-            schematronMap = parseSchematron(schematronDoc);
+            schematronMap = parseSchematron(schematronDoc, options);
 
             // Cache parsed schematron
             parsedMap[hash] = schematronMap;
@@ -332,12 +341,14 @@ async function validateAsync(xml, schematron, options = {}) {
                             };
                             if (type === 'error') {
                                 errors.push(obj);
-                            } else {
+                            }
+                            else {
                                 warnings.push(obj);
                             }
                         }
                     }
-                } else if (results.ignored) {
+                }
+                else if (results.ignored) {
                     const obj = {
                         errorMessage: errorMessage,
                         type: type,
@@ -371,7 +382,6 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
     const resultCapture = new Promise((resolve, reject) => {
         try {
             // Context cache
-            const includeWarnings = options.includeWarnings === undefined ? true : options.includeWarnings;
             const resourceDir = options.resourceDir || './';
             const xmlSnippetMaxLength = options.xmlSnippetMaxLength === undefined ? 200 : options.xmlSnippetMaxLength;
             const failedAssertions = [];
@@ -385,7 +395,8 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
                         contextModified = '//' + context;
                     }
                     selected = xpathSelect(contextModified, xmlDoc);
-                } else {
+                }
+                else {
                     selected = [xmlDoc];
                 }
                 contextMap[context] = selected;
@@ -400,7 +411,8 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
                     let simplifiedTest = null;
                     try {
                         test = includeExternalDocument(test, resourceDir);
-                    } catch (err) {
+                    }
+                    catch (err) {
                         failedAssertions.push({
                             type: level,
                             assertionId: id,
@@ -414,7 +426,7 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
                     if (originalTest !== test) {
                         simplifiedTest = test;
                     }
-                    if (level === 'error' || includeWarnings) {
+                    if (level === 'error' || _get(options, 'includeWarnings')) {
                         failedAssertions.push({
                             type: level,
                             assertionId: id,
@@ -424,7 +436,8 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
                             results: testAssertion(test, selected, xpathSelect, xmlDoc, resourceDir, xmlSnippetMaxLength)
                         });
                     }
-                } else {
+                }
+                else {
                     const extensionRule = assertionAndExtensionObject.rule;
                     if (!extensionRule) {
                         continue;
@@ -439,7 +452,8 @@ function checkRulePromise(xmlDoc, originalContext, assertionsAndExtensions, opti
                 }
             }
             resolve (failedAssertions);
-        } catch (promiseError) {
+        }
+        catch (promiseError) {
             reject (new Error (`Promise Error: ${promiseError}`));
         }
     });


### PR DESCRIPTION
- Major deviations from the source repository

  - By default the warning will be turned off in contrast to the parent repository

  - To get warnings, users have to explicitly specify the option `includeWarnings` with value boolean `true`

  - We also deviate from the previous behavior where all the checks for warnings were done at the assertion
    level just before testing the xpath. We now would not even parse the phase with @id="warnings" which should
    improve the performance.

- Minor cosmetic changes to the code